### PR TITLE
copyright text: use rem instead of px

### DIFF
--- a/src/easy-chat-frontend/src/app/components/content/content.component.html
+++ b/src/easy-chat-frontend/src/app/components/content/content.component.html
@@ -1,5 +1,5 @@
 <div class="container h-100 d-flex flex-column bg-white">
-  <div class="flex-grow-1"></div> <!-- placeholder for ChatHistory -->
+  <div class="flex-grow-1 h-100"></div> <!-- placeholder for ChatHistory -->
   <ec-currently-typing-bar class="flex-grow-0 "></ec-currently-typing-bar>
   <ec-chat-bar class="flex-grow-0"></ec-chat-bar>
 </div>

--- a/src/easy-chat-frontend/src/app/components/footer/footer.component.css
+++ b/src/easy-chat-frontend/src/app/components/footer/footer.component.css
@@ -3,5 +3,5 @@
 }
 
 .footerFont {
-  font-size: 12px;
+  font-size: 0.75rem;
 }


### PR DESCRIPTION
rem is relative to the the html element fontsize

https://chiamakaikeanyi.dev/sizing-in-css-px-vs-em-vs-rem/#:~:text=px%20is%20not%20scalable%2C%20it,px%20unit%20by%20the%20browser.