### PR TITLE
change header icon responsive behaviour

### DIFF
--- a/src/easy-chat-frontend/src/app/components/header/header.component.html
+++ b/src/easy-chat-frontend/src/app/components/header/header.component.html
@@ -1,6 +1,6 @@
 <nav class="container navbar navbar-dark static-top">
   <div class="navbar-brand">
-    <img src="assets/images/ost-logo.svg" height="auto" class="d-inline-block align-top mr-3" alt="logo">
-    EasyChat
+    <img src="assets/images/ost-logo.svg" height="48px" class="d-none d-sm-inline-block mr-3" alt="logo">
+    <h1 class="d-sm-inline-block align-middle">EasyChat</h1>
   </div>
 </nav>


### PR DESCRIPTION
- display logo only if screen size >= sm
- make title h1
- set fixed size of 48px for logo (necessary to avoid ugly header-resizing when shrinking the screen to mobile size)