### PR TITLE
fix: Trim for message

### DIFF
--- a/src/easy-chat-frontend/src/app/components/chat-bar/chat-bar.component.ts
+++ b/src/easy-chat-frontend/src/app/components/chat-bar/chat-bar.component.ts
@@ -9,7 +9,7 @@ import { ChatService } from '../../services/chat.service';
 export class ChatBarComponent implements OnInit {
 
   public message = '';
-  public get isValidToSend(): boolean { return this.message.length > 0; }
+  public get isValidToSend(): boolean { return this.message.trim().length > 0; }
 
   constructor(private chatService: ChatService) { }
 

--- a/src/easy-chat-frontend/src/app/components/currently-typing-bar/currently-typing-bar.component.ts
+++ b/src/easy-chat-frontend/src/app/components/currently-typing-bar/currently-typing-bar.component.ts
@@ -14,6 +14,7 @@ export class CurrentlyTypingBarComponent implements OnInit {
 
   ngOnInit(): void {
     this.chatService.currentMessage.subscribe((message) => {
+      message = message.trim()
       this.typingMessage = (message.length > 0) ? message + '...' : '';
     });
   }


### PR DESCRIPTION
fix: send button not active when textfield only contains 'spaces'
fix: message trimmed to not show leading and ending 'spaces' in currently-typing-bar